### PR TITLE
Правильная очистка памяти в Linux для Kestrel

### DIFF
--- a/RemoteForkCP/RemoteForkCP.csproj
+++ b/RemoteForkCP/RemoteForkCP.csproj
@@ -18,6 +18,7 @@
     <RepositoryUrl>https://github.com/ShutovPS/RemoteFork</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/ShutovPS/RemoteFork/blob/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
     <Copyright />
   </PropertyGroup>
 


### PR DESCRIPTION
Помогает держать расход оперативной памяти в рамках ~120MB 